### PR TITLE
Updated default pages to 2

### DIFF
--- a/plugin.video.einthusan/default.py
+++ b/plugin.video.einthusan/default.py
@@ -16,7 +16,7 @@ import requests
 
 # s = requests.Session()
 
-NUMBER_OF_PAGES = 3
+NUMBER_OF_PAGES = 2
 
 ADDON = xbmcaddon.Addon(id='plugin.video.einthusan')
 username = ADDON.getSetting('username')


### PR DESCRIPTION
Einthusan recently implemented rate limiting which is causing the add-on to generate outbound exception. Reducing the default pages to 2 fixes it. In future maybe we can use exponential backoff to avoid getting throttled